### PR TITLE
fix(collectives): fixing collective groups visibility level

### DIFF
--- a/seeds.rb
+++ b/seeds.rb
@@ -35,9 +35,9 @@ module DebtCollective
         group.assign_attributes(
           name: collective[:group][:name],
           full_name: collective[:group][:full_name],
-          mentionable_level: Group::ALIAS_LEVELS[:mods_and_admins],
+          mentionable_level: Group::ALIAS_LEVELS[:mods_and_admins], 
           messageable_level: Group::ALIAS_LEVELS[:mods_and_admins],
-          visibility_level: Group::ALIAS_LEVELS[:mods_and_admins],
+          visibility_level: Group.visibility_levels[:members],
           primary_group: true,
           public_admission: false,
           allow_membership_requests: false,


### PR DESCRIPTION
Using `visibility_levels` instead of `ALIAS_LEVELS` for visibility.

This fixes an issue with custom groups not being available in the front-end.