### PR TITLE
fix: Makefile sed command and seeds to check before creating permalinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ setup:
 
 # replace configuration files
 replace:
-	sed -i '' -e 's/\<discourse_development\>/debtcollective_discourse_development/' ../config/database.yml
+	sed -i '' -e "s/\'discourse_development\'/\'debtcollective_discourse_development\'/" ../config/database.yml
 
 # seed Discourse database
 seed:

--- a/seeds.rb
+++ b/seeds.rb
@@ -19,7 +19,7 @@ module DebtCollective
         color: '0088CC',
         text_color: 'FFFFFF',
         user: Discourse.system_user
-      ) 
+      )
       category.save
     end
 
@@ -47,7 +47,7 @@ module DebtCollective
         group.assign_attributes(
           name: collective[:group][:name],
           full_name: collective[:group][:full_name],
-          mentionable_level: Group::ALIAS_LEVELS[:mods_and_admins], 
+          mentionable_level: Group::ALIAS_LEVELS[:mods_and_admins],
           messageable_level: Group::ALIAS_LEVELS[:mods_and_admins],
           visibility_level: Group.visibility_levels[:members],
           primary_group: true,
@@ -131,7 +131,9 @@ module DebtCollective
     end
 
     def create_permalinks
-      Permalink.create(url: "donate", external_url: "https://tools.debtcollective.org/?donate")
+      donate_permalink = Permalink.find_by_url("donate")
+
+      Permalink.create(url: "donate", external_url: "https://tools.debtcollective.org/?donate") unless donate_permalink
     end
 
     def create_user_fields


### PR DESCRIPTION
**What:** Fix sed regex and check before creating Permalinks

**Why:** Installation was failing when you run it more than once, with this change it will be able to execute multiple times with the same result

**How:** 

- Check before creating Permalinks in `seed.rb`
- Change the sed regex to replace `database.yml` correctly
