### PR TITLE
fix: remove discourse-debtcollective-theme plugin in favor of theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ install:
 	../plugins/discourse-events \
 	../plugins/discourse-locations \
 	../plugins/discourse-custom-wizard \
-	../plugins/discourse-debtcollective-theme \
 	../plugins/discourse-debtcollective-wizards \
 	../plugins/discourse-debtcollective-private-message \
 	../plugins/discourse-debtcollective-sso \
@@ -25,7 +24,6 @@ install:
 	git clone https://github.com/angusmcleod/discourse-events.git ../plugins/discourse-events
 	git clone https://github.com/angusmcleod/discourse-locations.git ../plugins/discourse-locations
 	git clone https://github.com/angusmcleod/discourse-custom-wizard.git ../plugins/discourse-custom-wizard
-	git clone https://github.com/debtcollective/discourse-debtcollective-theme.git ../plugins/discourse-debtcollective-theme
 	git clone https://github.com/debtcollective/discourse-debtcollective-wizards.git ../plugins/discourse-debtcollective-wizards
 	git clone https://github.com/debtcollective/discourse-debtcollective-private-message.git ../plugins/discourse-debtcollective-private-message
 	git clone https://github.com/debtcollective/discourse-debtcollective-sso.git ../plugins/discourse-debtcollective-sso

--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ env DISCOURSE_ENABLE_CORS=true rails s
 
 We are using these themes/theme components.
 
-- [Versatile Banner](https://meta.discourse.org/t/versatile-banner/109133)
+- [Discourse Debt Collective](https://github.com/debtcollective/discourse-debtcollective-theme)
 
-The installation of these is not automated and have to be installed manually. Here's a [guide on how to install theme or theme components](https://meta.discourse.org/t/how-do-i-install-a-theme-or-theme-component/63682)
+Follow the instructions on the repo on how to install it

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ rake admin:create
 and we run the server
 
 ```bash
-env DISCOURSE_ENABLE_CORS=true rails s
+env DISCOURSE_ENABLE_CORS=true DISCOURSE_DEV_HOST=lvh.me DISCOURSE_SSO_JWT_SECRET=jwt-secret rails s
 ```
 
 ## Additional Steps

--- a/seeds.rb
+++ b/seeds.rb
@@ -178,7 +178,8 @@ module DebtCollective
       puts('Creating Welcome wizard')
 
       json = File.read(File.join(__dir__, 'data/welcome_wizard.json'))
-      CustomWizard::Wizard.add_wizard(json)
+      obj = JSON.parse(json)
+      CustomWizard::Wizard.add_wizard(obj)
     end
 
     def create_permalinks


### PR DESCRIPTION
**What:** remove discourse-debtcollective-theme plugin in favor of theme

**Why:** To have the discourse-import running correctly

**How:**

- Remove discourse-debtcollective-theme install
- Change `create_welcome_wizard` to pass ruby object instead of a String to `CustomWizard::Wizard.add_wizard` method