### PR TITLE
feat: sync local discourse version with production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 # default command
-bootstrap: setup replace migrate install seed clean
+bootstrap: setup replace version-lock install migrate seed clean
+
+# sync discourse version with production
+version-lock:
+	cd ".."; git checkout tests-passed
+	cd ".."; git pull origin tests-passed
+	cd ".."; git checkout $$(curl -s https://community.debtcollective.org | sed -n '/\<meta/s/\<meta[[:space:]][[:space:]]*name="*generator"*[[:space:]][[:space:]]*content="*\([^"]*\)"*\>/\1/p' | awk '{ print $$NF }')
 
 # clone all dependencies to plugins/
 install:


### PR DESCRIPTION
**What:** sync local discourse version with production

This will be done as part of the `make setup` command

![image](https://user-images.githubusercontent.com/849872/88442576-a9968500-cdda-11ea-9e00-cace71b58af9.png)

**Why:** Closes https://app.asana.com/0/1168997577035609/1185355039772619

**How:**

- Pull the current commit we are running on production via curl and checkout that commit locally.